### PR TITLE
notebook example

### DIFF
--- a/example/consumer.ipynb
+++ b/example/consumer.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "237ea6b1-85ac-4deb-a43a-a282b7078156",
+   "metadata": {},
+   "source": [
+    "# `fastapi-h5` consumer\n",
+    "\n",
+    "This notebook is the `h5pyd` consumer/client of data published with `fastapi-h5` service.\n",
+    "\n",
+    "It does require neither `fastapi` or `fastapi-h5`. They arer used by the publisher/server.<br>\n",
+    "There is a FastAPI interface exposed at [http://localhost:8000/docs](http://localhost:8000/docs) but that is not used.<br>\n",
+    "The only requirement is the `h5pyd` client module and the h5py-like methods are used to access data.\n",
+    "\n",
+    "*This example demonstrates a basic communcation between 2 notebooks or Python processes without files and using [Hierarchical Data Format](https://www.hdfgroup.org/) (HDF) model.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0a73ff3a-8036-4655-a635-63b766e3df85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install h5pyd==0.21.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "95981773-ca24-445a-835a-78ff6f97ebf7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "h5pyd version: 0.21.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import h5pyd\n",
+    "print('h5pyd version:', h5pyd.version.version)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89f9c761-5a5a-4402-9c11-a43c3c3f6e7b",
+   "metadata": {},
+   "source": [
+    "Note:\n",
+    "- the endpoint is at [http://localhost:8000/results](http://localhost:8000/results) including the `prefix='results'` that was set as an optional argument in the Publisher\n",
+    "- `fast-api` does not provide filesystem-like access to folders and domains. The HDF-model starts with the root: `\"/\"` and data are read-only."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "119a7f19-46d8-454a-b4bc-c40c0df84aad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<HDF5 group \"/entry/time/\" (7 members)>\n",
+      "/entry/time/tm_hour: value=11, dtype=int64\n",
+      "h5dict time data: 11:41:11 UTC\n",
+      "<HDF5 dataset \"values\": shape (10,), type \"<f2\">\n",
+      "\tdset values: [0. 1. 2. 3. 4. 5. 6. 7. 8. 9.]\n",
+      "\tdset dtype: float16\n",
+      "\tattr name=NX_class, value=NXdata\n",
+      "\tattr name=signal, value=values\n"
+     ]
+    }
+   ],
+   "source": [
+    "with h5pyd.File(\"/\", \"r\", endpoint=\"http://localhost:8000/results\") as f:\n",
+    "    # group\n",
+    "    g = f[\"/entry/time/\"]\n",
+    "    print(g)\n",
+    "    # single value dataset\n",
+    "    dset = g[\"tm_hour\"]\n",
+    "    print('/entry/time/tm_hour: value=%d, dtype=%s' % (dset.value, dset.dtype,))\n",
+    "    # dynamic datasets values\n",
+    "    print(\"h5dict time data: %02d:%02d:%02d %s\" % (g[\"tm_hour\"].value, g[\"tm_min\"].value, g[\"tm_sec\"].value, g[\"tm_zone\"].value.decode('UTF-8')))\n",
+    "    # array dataset with NeXus attributes\n",
+    "    dset = f[\"/entry/data/values\"] \n",
+    "    print(dset)\n",
+    "    print('\\tdset values:', dset[()])\n",
+    "    print('\\tdset dtype:', dset.dtype)\n",
+    "    attrs = f[\"/entry/data\"].attrs\n",
+    "    for name in attrs:\n",
+    "        print('\\tattr name=%s, value=%s' % (name, attrs[name],))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19bd0a88-0371-471b-8ddb-bb18ca7079ba",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/example/publisher.ipynb
+++ b/example/publisher.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ca21d8bc-9922-4884-8a28-a08c70b826ea",
+   "metadata": {},
+   "source": [
+    "# `fastapi-h5` publisher\n",
+    "\n",
+    "This notebook will create FastAPI application publishing HSDS-like data via `fastapi-h5.router`.\n",
+    "\n",
+    "The notebook uses `typing`, `contextlib` and `asyncio` from standard Python.<br>\n",
+    "Concerning the external dependencies, beside `fastapi` and `fastapi-h5`, it requires `uvicorn` and `numpy` (optional).\n",
+    "\n",
+    "*This example demonstrates a basic communcation between 2 notebooks or Python processes without files and using [Hierarchical Data Format](https://www.hdfgroup.org/) (HDF) model.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cf7f59a4-86da-488a-8213-0fc95ef690d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastapi_h5 import router\n",
+    "\n",
+    "from contextlib import nullcontext\n",
+    "from fastapi import FastAPI\n",
+    "import uvicorn, time, asyncio\n",
+    "from typing import Any, ContextManager, Tuple\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a82689c6-7bc8-4e9a-8cc8-c87fa2a5d1e4",
+   "metadata": {},
+   "source": [
+    "- create FastAPI application\n",
+    "- add the `fastapi_h5.router`\n",
+    "- define a function or method returning data\n",
+    "- link that function to `app.state.get_data`\n",
+    "- configure uvicor server\n",
+    "- note that attributes are supported so [NeXus](https://www.nexusformat.org/) convention can be used\n",
+    "- run the server forewer (you can use the Notebook *interrupt* to stop the server)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "259845b9-0578-4786-afbe-838faec0611b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:     Started server process [52925]\n",
+      "INFO:     Waiting for application startup.\n",
+      "INFO:     Application startup complete.\n",
+      "INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:     127.0.0.1:55472 - \"GET /results/?getdnids=1&getobjs=T&include_attrs=T&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F/links/entry?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E747279/links/time?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F74696D65?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F74696D65/links/tm_hour?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F686F7572?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F686F7572/value?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F686F7572/value?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F74696D65/links/tm_min?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F6D696E?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F6D696E/value?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F74696D65/links/tm_sec?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F736563?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F736563/value?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F74696D65/links/tm_zone?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F7A6F6E65?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F74696D652F746D5F7A6F6E65/value?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E747279/links/data?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F64617461/links/values?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F646174612F76616C756573?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/datasets/d-h5dict-2F656E7472792F646174612F76616C756573/value?nonstrict=1&select=%5B0%3A10%3A1%5D&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F64617461?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F64617461/attributes?CreateOrder=0&domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F64617461/attributes/NX_class?domain=%2F HTTP/1.1\" 200 OK\n",
+      "INFO:     127.0.0.1:55472 - \"GET /results/groups/g-h5dict-2F656E7472792F64617461/attributes/signal?domain=%2F HTTP/1.1\" 200 OK\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:     Shutting down\n",
+      "INFO:     Waiting for application shutdown.\n",
+      "INFO:     Application shutdown complete.\n",
+      "INFO:     Finished server process [52925]\n"
+     ]
+    }
+   ],
+   "source": [
+    "app = FastAPI()\n",
+    "\n",
+    "# add h5dict RestAPI port\n",
+    "app.include_router(router, prefix=\"/results\")\n",
+    "\n",
+    "# data published over HSDS-like interface\n",
+    "def get_data() -> Tuple[dict[str, Any], ContextManager[None]]:\n",
+    "    t = time.time()\n",
+    "    gmt = time.gmtime(t)\n",
+    "    data = {\n",
+    "        \"entry\": {\n",
+    "            \"time\": {\n",
+    "                \"tm_year\": gmt.tm_year,\n",
+    "                \"tm_mon\":  gmt.tm_mon,\n",
+    "                \"tm_mday\": gmt.tm_mday,\n",
+    "                \"tm_hour\": gmt.tm_hour,\n",
+    "                \"tm_min\":  gmt.tm_min,\n",
+    "                \"tm_sec\":  gmt.tm_sec,\n",
+    "                \"tm_zone\": gmt.tm_zone,\n",
+    "            },\n",
+    "            \"time_attrs\": {\"NX_class\": \"NXcollection\"},\n",
+    "            \"data\": {\n",
+    "                \"values\": np.arange(10, dtype=np.float16),\n",
+    "            },\n",
+    "            \"data_attrs\": {\"NX_class\": \"NXdata\", \"signal\": \"values\"},\n",
+    "        },\n",
+    "        \"entry_attrs\": {\"NX_class\": \"NXentry\", \"default\": \"data\"},\n",
+    "        \"_attrs\": {\"default\": \"entry\"},\n",
+    "    }\n",
+    "    return data, nullcontext()\n",
+    "\n",
+    "app.state.get_data = get_data\n",
+    "\n",
+    "# configure uvicorn server\n",
+    "config = uvicorn.Config(app, host='0.0.0.0', port=8000, log_level=\"info\")\n",
+    "server = uvicorn.Server(config)\n",
+    "\n",
+    "# run forewer\n",
+    "await server.serve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5ac6d93-dcff-4d76-bab3-81d04b30b183",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Jupyter notebook example of `fastapi-h5` publisher and consumer as presented the [European HUG 2025](https://doi.org/10.5281/zenodo.15731472).

Updates:
- converted from `dranspose` to `fastapi-h5`
- adjusted to extended `fastapi-h5` interface
- added comments
- improved NeXus decoration for default plotting

Known issues:
- silx-2.2.2 does not like using the `prefix='results'`. They are ignoring it as the endpoint address and parsing it as a domain.